### PR TITLE
Python3 support

### DIFF
--- a/repoze/catalog/__init__.py
+++ b/repoze/catalog/__init__.py
@@ -1,5 +1,6 @@
 
-class RangeValue:
+from builtins import object
+class RangeValue(object):
     """ Use in fieldindex query above to indicate a range search for a term """
     def __init__(self, start, end):
         self.start = start

--- a/repoze/catalog/catalog.py
+++ b/repoze/catalog/catalog.py
@@ -102,7 +102,8 @@ class Catalog(PersistentMapping):
             if not results:
                 return EMPTY_RESULT
 
-            results.sort() # order from smallest to largest
+            # order from smallest to largest
+            results = sorted(results, key=len)
             _, result = results.pop(0)
             for _, r in results:
                 _, result = self.family.IF.weightedIntersection(result, r)

--- a/repoze/catalog/catalog.py
+++ b/repoze/catalog/catalog.py
@@ -4,14 +4,14 @@ import BTrees
 from persistent.mapping import PersistentMapping
 import transaction
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from repoze.catalog.interfaces import ICatalog
 from repoze.catalog.interfaces import ICatalogIndex
 
-class Catalog(PersistentMapping):
 
-    implements(ICatalog)
+@implementer(ICatalog)
+class Catalog(PersistentMapping):
 
     family = BTrees.family32
 

--- a/repoze/catalog/catalog.py
+++ b/repoze/catalog/catalog.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 import BTrees
 from persistent.mapping import PersistentMapping
 import transaction
@@ -20,20 +22,20 @@ class Catalog(PersistentMapping):
 
     def clear(self):
         """ Clear all indexes in this catalog. """
-        for index in self.values():
+        for index in list(self.values()):
             index.clear()
 
     def index_doc(self, docid, obj):
         """Register the document represented by ``obj`` in indexes of
         this catalog using docid ``docid``."""
         assertint(docid)
-        for index in self.values():
+        for index in list(self.values()):
             index.index_doc(docid, obj)
 
     def unindex_doc(self, docid):
         """Unregister the document id from indexes of this catalog."""
         assertint(docid)
-        for index in self.values():
+        for index in list(self.values()):
             index.unindex_doc(docid)
 
     def reindex_doc(self, docid, obj):
@@ -42,7 +44,7 @@ class Catalog(PersistentMapping):
         ``unindex_doc``, then ``index_doc``, but specialized indexes
         can override the method that this API calls to do less work. """
         assertint(docid)
-        for index in self.values():
+        for index in list(self.values()):
             index.reindex_doc(docid, obj)
 
     def __setitem__(self, name, index):
@@ -86,7 +88,7 @@ class Catalog(PersistentMapping):
         if index_query_order is None:
             # unordered query (use apply)
             results = []
-            for index_name, index_query in query.items():
+            for index_name, index_query in list(query.items()):
                 index = self.get(index_name)
                 if index is None:
                     raise ValueError('No such index %s' % index_name)

--- a/repoze/catalog/document.py
+++ b/repoze/catalog/document.py
@@ -179,7 +179,7 @@ class DocumentMap(Persistent):
         """
         if not docid in self.docid_to_address:
             raise KeyError(docid)
-        if len(data.keys()) == 0:
+        if len(list(data.keys())) == 0:
             return
         self._check_metadata()
         meta = self.docid_to_metadata.setdefault(docid, OOBTree())

--- a/repoze/catalog/indexes/common.py
+++ b/repoze/catalog/indexes/common.py
@@ -1,3 +1,5 @@
+from past.builtins import basestring
+from builtins import object
 from persistent import Persistent
 from ZODB.broken import Broken
 import BTrees

--- a/repoze/catalog/indexes/facet.py
+++ b/repoze/catalog/indexes/facet.py
@@ -1,3 +1,4 @@
+from past.builtins import basestring
 try:
     from hashlib import md5
 except: # pragma no cover

--- a/repoze/catalog/indexes/facet.py
+++ b/repoze/catalog/indexes/facet.py
@@ -5,13 +5,15 @@ except: # pragma no cover
     from md5 import new as md5
 
 from persistent import Persistent
-from zope.interface import implements
+from zope.interface import implementer
 
 from repoze.catalog.indexes.keyword import CatalogKeywordIndex
 from repoze.catalog.interfaces import ICatalogIndex
 
 _marker = ()
 
+
+@implementer(ICatalogIndex)
 class CatalogFacetIndex(CatalogKeywordIndex):
     """Facet index.
 
@@ -33,7 +35,6 @@ class CatalogFacetIndex(CatalogKeywordIndex):
 
     - NotAll
     """
-    implements(ICatalogIndex)
 
     def __init__(self, discriminator, facets, family=None):
         if not callable(discriminator):

--- a/repoze/catalog/indexes/facet.py
+++ b/repoze/catalog/indexes/facet.py
@@ -142,6 +142,5 @@ class CatalogFacetIndex(CatalogKeywordIndex):
 def cachekey(set):
     h = md5()
     for item in sorted(list(set)):
-        h.update(item)
+        h.update(item.encode('utf-8'))
     return h.hexdigest()
-

--- a/repoze/catalog/indexes/field.py
+++ b/repoze/catalog/indexes/field.py
@@ -5,7 +5,7 @@ import bisect
 import heapq
 from itertools import islice
 
-from zope.interface import implements
+from zope.interface import implementer
 
 from zope.index.field import FieldIndex
 
@@ -20,6 +20,7 @@ NBEST = 'nbest'
 TIMSORT = 'timsort'
 
 
+@implementer(ICatalogIndex)
 class CatalogFieldIndex(CatalogIndex, FieldIndex):
     """ Field indexing.
 
@@ -49,7 +50,6 @@ class CatalogFieldIndex(CatalogIndex, FieldIndex):
 
     - NotInRange
     """
-    implements(ICatalogIndex)
 
     def __init__(self, discriminator):
         if not callable(discriminator):

--- a/repoze/catalog/indexes/field.py
+++ b/repoze/catalog/indexes/field.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from past.builtins import basestring
+from past.utils import old_div
 import bisect
 import heapq
 from itertools import islice
@@ -92,7 +95,7 @@ class CatalogFieldIndex(CatalogIndex, FieldIndex):
         self._num_docs.change(-1)
 
     def _indexed(self):
-        return self._rev_index.keys()
+        return list(self._rev_index.keys())
 
     def sort(self, docids, reverse=False, limit=None, sort_type=None):
         if not docids:
@@ -150,7 +153,7 @@ class CatalogFieldIndex(CatalogIndex, FieldIndex):
             # XXX this needs work.
             rlen = len(docids)
             if limit:
-                if (limit < 300) or (limit/float(rlen) > 0.09):
+                if (limit < 300) or (old_div(limit,float(rlen)) > 0.09):
                     sort_type = NBEST
                 else:
                     sort_type = TIMSORT
@@ -170,7 +173,7 @@ class CatalogFieldIndex(CatalogIndex, FieldIndex):
         fwd_index = self._fwd_index
 
         n = 0
-        for set in fwd_index.values():
+        for set in list(fwd_index.values()):
             for docid in set:
                 if docid in docids:
                     n+=1
@@ -322,37 +325,37 @@ def fwscan_wins(limit, rlen, numdocs):
     work, but accuracy at very small index sizes is not terribly
     important for the author.
     """
-    docratio = rlen / float(numdocs)
+    docratio = old_div(rlen, float(numdocs))
 
     if limit:
-        limitratio = limit / float(numdocs)
+        limitratio = old_div(limit, float(numdocs))
     else:
         limitratio = 1
 
     div = 65536.0
 
-    if docratio >= 16384/div:
+    if docratio >= old_div(16384,div):
         # forward scan tends to beat nbest or timsort reliably when
         # the rlen is greater than a quarter of the number of
         # documents in the index
         return True
 
-    if docratio >= 256/div:
+    if docratio >= old_div(256,div):
         # depending on the limit ratio, forward scan still has a
         # chance to win over nbest or timsort even if the rlen is
         # smaller than a quarter of the number of documents in the
         # index, beginning reliably at a docratio of 512/65536.0.  XXX
         # It'd be nice to figure out a more concise way to express
         # this.
-        if 512/div <= docratio < 1024/div and limitratio <= 4/div:
+        if old_div(512,div) <= docratio < old_div(1024,div) and limitratio <= old_div(4,div):
             return True
-        elif  1024/div <= docratio < 2048/div and limitratio <= 32/div:
+        elif  old_div(1024,div) <= docratio < old_div(2048,div) and limitratio <= old_div(32,div):
             return True
-        elif 2048/div <= docratio < 4096/div and limitratio <= 128/div:
+        elif old_div(2048,div) <= docratio < old_div(4096,div) and limitratio <= old_div(128,div):
             return True
-        elif 4096/div <= docratio < 8192/div and limitratio <= 512/div:
+        elif old_div(4096,div) <= docratio < old_div(8192,div) and limitratio <= old_div(512,div):
             return True
-        elif 8192/div <= docratio < 16384/div and limitratio <= 4096/div:
+        elif old_div(8192,div) <= docratio < old_div(16384,div) and limitratio <= old_div(4096,div):
             return True
 
     return False
@@ -369,24 +372,24 @@ def nbest_ascending_wins(limit, rlen, numdocs):
     if not limit:
         # n-best can't be used without a limit
         return False
-    limitratio = limit / float(numdocs)
+    limitratio = old_div(limit, float(numdocs))
 
     if numdocs <= 768:
         return True
 
-    docratio = rlen / float(numdocs)
+    docratio = old_div(rlen, float(numdocs))
     div = 65536.0
 
-    if docratio < 4096/div:
+    if docratio < old_div(4096,div):
         # nbest tends to win when the rlen is less than about 6% of the
         # numdocs
         return True
 
-    if docratio == 1 and limitratio <= 8192/div:
+    if docratio == 1 and limitratio <= old_div(8192,div):
         return True
-    elif 1 > docratio >= 32768/div and limitratio <= 4096/div:
+    elif 1 > docratio >= old_div(32768,div) and limitratio <= old_div(4096,div):
         return True
-    elif 32768/div > docratio >= 4096/div and limitratio <= 2048/div:
+    elif old_div(32768,div) > docratio >= old_div(4096,div) and limitratio <= old_div(2048,div):
         return True
 
     return False

--- a/repoze/catalog/indexes/field.py
+++ b/repoze/catalog/indexes/field.py
@@ -180,7 +180,7 @@ class CatalogFieldIndex(CatalogIndex, FieldIndex):
 
     def nbest_ascending(self, docids, limit):
         if limit is None: #pragma NO COVERAGE
-            raise RuntimeError, 'n-best used without limit'
+            raise RuntimeError('n-best used without limit')
 
         # lifted from heapq.nsmallest
 
@@ -204,7 +204,7 @@ class CatalogFieldIndex(CatalogIndex, FieldIndex):
 
     def nbest_descending(self, docids, limit):
         if limit is None: #pragma NO COVERAGE
-            raise RuntimeError, 'N-Best used without limit'
+            raise RuntimeError('N-Best used without limit')
         iterable = nsort(docids, self._rev_index)
         for value, docid in heapq.nlargest(limit, iterable):
             yield docid

--- a/repoze/catalog/indexes/keyword.py
+++ b/repoze/catalog/indexes/keyword.py
@@ -1,3 +1,4 @@
+from past.builtins import basestring
 from zope.interface import implements
 
 from zope.index.keyword import KeywordIndex
@@ -45,7 +46,7 @@ class CatalogKeywordIndex(CatalogIndex, KeywordIndex):
         return self.index_doc(docid, value)
 
     def _indexed(self):
-        return self._rev_index.keys()
+        return list(self._rev_index.keys())
 
     def applyAny(self, values):
         return self.apply({'query': values, 'operator': 'or'})

--- a/repoze/catalog/indexes/keyword.py
+++ b/repoze/catalog/indexes/keyword.py
@@ -1,5 +1,5 @@
 from past.builtins import basestring
-from zope.interface import implements
+from zope.interface import implementer
 
 from zope.index.keyword import KeywordIndex
 
@@ -7,6 +7,7 @@ from repoze.catalog.interfaces import ICatalogIndex
 from repoze.catalog.indexes.common import CatalogIndex
 
 
+@implementer(ICatalogIndex)
 class CatalogKeywordIndex(CatalogIndex, KeywordIndex):
     """
     Keyword index.
@@ -30,7 +31,6 @@ class CatalogKeywordIndex(CatalogIndex, KeywordIndex):
     - NotAll
 
     """
-    implements(ICatalogIndex)
 
     def __init__(self, discriminator):
         if not callable(discriminator):

--- a/repoze/catalog/indexes/path.py
+++ b/repoze/catalog/indexes/path.py
@@ -1,3 +1,6 @@
+from past.builtins import cmp
+from builtins import range
+from past.builtins import basestring
 from zope.interface import implements
 from persistent import Persistent
 
@@ -99,7 +102,7 @@ class CatalogPathIndex(CatalogIndex):
         if isinstance(path, (list, tuple)):
             path = '/'+ '/'.join(path[1:])
 
-        comps = filter(None, path.split('/'))
+        comps = [_f for _f in path.split('/') if _f]
 
         if docid not in self._unindex:
             self._length.change(1)
@@ -138,7 +141,7 @@ class CatalogPathIndex(CatalogIndex):
         del self._unindex[docid]
 
     def _indexed(self):
-        return self._unindex.keys()
+        return list(self._unindex.keys())
 
     def search(self, path, default_level=0):
         """
@@ -155,10 +158,10 @@ class CatalogPathIndex(CatalogIndex):
             level = int(path[1])
             path  = path[0]
 
-        comps = filter(None, path.split('/'))
+        comps = [_f for _f in path.split('/') if _f]
 
         if len(comps) == 0:
-            return self.family.IF.Set(self._unindex.keys())
+            return self.family.IF.Set(list(self._unindex.keys()))
 
         results = None
         if level >= 0:

--- a/repoze/catalog/indexes/path.py
+++ b/repoze/catalog/indexes/path.py
@@ -1,7 +1,7 @@
 from past.builtins import cmp
 from builtins import range
 from past.builtins import basestring
-from zope.interface import implements
+from zope.interface import implementer
 from persistent import Persistent
 
 import BTrees
@@ -13,6 +13,8 @@ from repoze.catalog.indexes.common import CatalogIndex
 
 _marker = ()
 
+
+@implementer(ICatalogIndex)
 class CatalogPathIndex(CatalogIndex):
 
     """Index for model paths (tokens separated by '/' characters)
@@ -36,7 +38,6 @@ class CatalogPathIndex(CatalogIndex):
     - NotEq
 
     """
-    implements(ICatalogIndex)
     useOperator = 'or'
 
     family = BTrees.family32

--- a/repoze/catalog/indexes/path.py
+++ b/repoze/catalog/indexes/path.py
@@ -223,7 +223,7 @@ class CatalogPathIndex(CatalogIndex):
 
         else:
             rs = None
-            sets.sort(lambda x, y: cmp(len(x), len(y)))
+            sets = sorted(sets, key=len)
             for set in sets:
                 rs = self.family.IF.intersection(rs, set)
                 if not rs:

--- a/repoze/catalog/indexes/path.py
+++ b/repoze/catalog/indexes/path.py
@@ -61,10 +61,10 @@ class CatalogPathIndex(CatalogIndex):
            level is the level of the component inside the path
         """
 
-        if not self._index.has_key(comp):
+        if comp not in self._index:
             self._index[comp] = self.family.IO.BTree()
 
-        if not self._index[comp].has_key(level):
+        if level not in self._index[comp]:
             self._index[comp][level] = self.family.IF.TreeSet()
 
         self._index[comp][level].insert(id)
@@ -101,7 +101,7 @@ class CatalogPathIndex(CatalogIndex):
 
         comps = filter(None, path.split('/'))
 
-        if not self._unindex.has_key(docid):
+        if docid not in self._unindex:
             self._length.change(1)
 
         for i in range(len(comps)):
@@ -115,7 +115,7 @@ class CatalogPathIndex(CatalogIndex):
         if docid in _not_indexed:
             _not_indexed.remove(docid)
 
-        if not self._unindex.has_key(docid):
+        if docid not in self._unindex:
             return
 
         comps =  self._unindex[docid].split('/')
@@ -163,9 +163,9 @@ class CatalogPathIndex(CatalogIndex):
         results = None
         if level >= 0:
             for i, comp in enumerate(comps):
-                if not self._index.has_key(comp):
+                if comp not in self._index:
                     return self.family.IF.Set()
-                if not self._index[comp].has_key(level+i):
+                if level+i not in self._index[comp]:
                     return self.family.IF.Set()
                 results = self.family.IF.intersection(
                     results, self._index[comp][level+i])

--- a/repoze/catalog/indexes/path2.py
+++ b/repoze/catalog/indexes/path2.py
@@ -1,7 +1,7 @@
 from builtins import str
 from builtins import range
 from past.builtins import basestring
-from zope.interface import implements
+from zope.interface import implementer
 
 import BTrees
 
@@ -11,6 +11,7 @@ from repoze.catalog.indexes.common import CatalogIndex
 _marker = object()
 
 
+@implementer(ICatalogIndex)
 class CatalogPathIndex2(CatalogIndex):  #pragma NO COVERAGE
     """
     DEPRECATED
@@ -34,7 +35,6 @@ class CatalogPathIndex2(CatalogIndex):  #pragma NO COVERAGE
     Eq
 
     """
-    implements(ICatalogIndex)
     attr_discriminator = None # b/w compat
 
     family = BTrees.family32

--- a/repoze/catalog/indexes/path2.py
+++ b/repoze/catalog/indexes/path2.py
@@ -1,3 +1,6 @@
+from builtins import str
+from builtins import range
+from past.builtins import basestring
 from zope.interface import implements
 
 import BTrees
@@ -59,7 +62,7 @@ class CatalogPathIndex2(CatalogIndex):  #pragma NO COVERAGE
     def __len__(self):
         return len(self.docid_to_path)
 
-    def __nonzero__(self):
+    def __bool__(self):
         return True
 
     def _getPathTuple(self, path):
@@ -188,7 +191,7 @@ class CatalogPathIndex2(CatalogIndex):  #pragma NO COVERAGE
             return False
 
     def _indexed(self):
-        return self.docid_to_path.keys()
+        return list(self.docid_to_path.keys())
 
     def search(self, path, depth=None, include_path=False, attr_checker=None):
         """ Provided a path string (e.g. ``/path/to/object``) or a
@@ -334,7 +337,7 @@ class CatalogPathIndex2(CatalogIndex):  #pragma NO COVERAGE
                         continue
                     stack.append((newpath, attrs[:]))
 
-        return attr_checker(result.values())
+        return attr_checker(list(result.values()))
 
     def apply_intersect(self, query, docids):
         """ Default apply_intersect implementation """
@@ -372,7 +375,7 @@ class CatalogPathIndex2(CatalogIndex):  #pragma NO COVERAGE
         return self.apply(query)
 
 def add_to_closest(sofar, thispath, theset):
-    paths = sorted(sofar.keys(), reverse=True)
+    paths = sorted(list(sofar.keys()), reverse=True)
     for path in paths:
         pathlen = len(path)
         if thispath[:pathlen] == path:
@@ -380,7 +383,7 @@ def add_to_closest(sofar, thispath, theset):
             break
 
 def remove_from_closest(sofar, thispath, docid):
-    paths = sorted(sofar.keys(), reverse=True)
+    paths = sorted(list(sofar.keys()), reverse=True)
     for path in paths:
         pathlen = len(path)
         if thispath[:pathlen] == path:

--- a/repoze/catalog/indexes/tests/test_common.py
+++ b/repoze/catalog/indexes/tests/test_common.py
@@ -199,11 +199,10 @@ class TestCatalogIndex(unittest.TestCase):
 
 
 from repoze.catalog.interfaces import ICatalogIndex
-from zope.interface import implements
+from zope.interface import implementer
 
-
+@implementer(ICatalogIndex)
 class DummyIndex(object):
-    implements(ICatalogIndex)
 
     value = None
 

--- a/repoze/catalog/indexes/tests/test_common.py
+++ b/repoze/catalog/indexes/tests/test_common.py
@@ -1,3 +1,4 @@
+from builtins import object
 import unittest
 
 class TestCatalogIndex(unittest.TestCase):
@@ -76,7 +77,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             abc = 'abc'
         dummy = Dummy()
         self.assertEqual(index.index_doc(1, dummy), 'abc')
@@ -89,7 +90,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.abc = 'abc'
@@ -107,7 +108,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         self.assertEqual(index.index_doc(20, dummy), None)
@@ -122,7 +123,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         self.assertEqual(index.index_doc(20, dummy), None)
@@ -136,7 +137,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         self.assertEqual(index.index_doc(20, dummy), None)
@@ -151,7 +152,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.abc = Persistent()
@@ -164,7 +165,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.abc = Broken()
@@ -176,7 +177,7 @@ class TestCatalogIndex(unittest.TestCase):
             pass
         index = Test('abc')
         index._docids = set()
-        class Dummy:
+        class Dummy(object):
             abc = 'abc'
         dummy = Dummy()
         index.index_doc(1, dummy)

--- a/repoze/catalog/indexes/tests/test_facet.py
+++ b/repoze/catalog/indexes/tests/test_facet.py
@@ -1,3 +1,4 @@
+from builtins import object
 import unittest
 
 FACETS = [
@@ -89,7 +90,7 @@ class TestCatalogFacetIndex(unittest.TestCase):
 
     def test_index_doc_string_discriminator(self):
         OTHER_FACETS = ['foo', 'foo:bar', 'foo:baz']
-        class Dummy:
+        class Dummy(object):
             facets = ['foo:bar']
         index = self._makeOne('facets', OTHER_FACETS)
         index.index_doc(1, Dummy())
@@ -99,7 +100,7 @@ class TestCatalogFacetIndex(unittest.TestCase):
 
     def test_index_doc_missing_value_unindexes(self):
         OTHER_FACETS = ['foo', 'foo:bar', 'foo:baz']
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.facets = ['foo:bar']
@@ -114,7 +115,7 @@ class TestCatalogFacetIndex(unittest.TestCase):
     def test_index_doc_persistent_value_raises(self):
         from persistent import Persistent
         OTHER_FACETS = ['foo', 'foo:bar', 'foo:baz']
-        class Dummy:
+        class Dummy(object):
             pass
         index = self._makeOne('facets', OTHER_FACETS)
         dummy = Dummy()
@@ -123,7 +124,7 @@ class TestCatalogFacetIndex(unittest.TestCase):
 
     def test_index_doc_unindexes_old_values(self):
         OTHER_FACETS = ['foo', 'foo:bar', 'foo:baz']
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.facets = ['foo:bar']

--- a/repoze/catalog/indexes/tests/test_field.py
+++ b/repoze/catalog/indexes/tests/test_field.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from builtins import range
+from past.utils import old_div
 import unittest
 
 _marker = object()
@@ -56,7 +59,7 @@ class TestCatalogFieldIndex(unittest.TestCase):
     def test_reindex_doc_doesnt_unindex(self):
         index = self._makeOne()
         index.index_doc(5, 1)
-        index.unindex_doc = lambda *args, **kw: 1 / 0
+        index.unindex_doc = lambda *args, **kw: old_div(1, 0)
         index.reindex_doc(5, 1)
 
     def test_reindex_doc_w_existing_docid_same_value(self):
@@ -220,7 +223,7 @@ class TestCatalogFieldIndex(unittest.TestCase):
             index.index_doc(i, i)
             c1.insert(i)
         result = index.sort(c1, reverse=True, limit=301) # waaa
-        self.assertEqual(list(result), range(9999, 9698, -1))
+        self.assertEqual(list(result), list(range(9999, 9698, -1)))
 
     def test_sort_force_fwscan_no_limit(self):
         from BTrees.IFBTree import IFSet

--- a/repoze/catalog/indexes/tests/test_keyword.py
+++ b/repoze/catalog/indexes/tests/test_keyword.py
@@ -1,3 +1,5 @@
+from __future__ import division
+from past.utils import old_div
 import unittest
 
 _marker = object()
@@ -48,7 +50,7 @@ class TestCatalogKeywordIndex(unittest.TestCase):
     def test_reindex_doc_doesnt_unindex(self):
         index = self._makeOne()
         index.index_doc(5, [1])
-        index.unindex_doc = lambda *args, **kw: 1 / 0
+        index.unindex_doc = lambda *args, **kw: old_div(1, 0)
         index.reindex_doc(5, [1])
 
     def test_reindex_doc_same_values(self):

--- a/repoze/catalog/indexes/tests/test_path.py
+++ b/repoze/catalog/indexes/tests/test_path.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import unittest
 
 _marker = object()
@@ -20,7 +22,7 @@ class PathIndexTests(unittest.TestCase):
         if discriminator is _marker:
             discriminator = _discriminator
         index = self._getTargetClass()(discriminator)
-        for doc_id, path in values.items():
+        for doc_id, path in list(values.items()):
             index.index_doc(doc_id, path)
         return index
 
@@ -111,7 +113,7 @@ class PathIndexTests(unittest.TestCase):
 
     def test_index_doc_string_discrim(self):
         index = self._makeOne(discriminator='abc')
-        class Dummy:
+        class Dummy(object):
             abc = '/a/b/c'
         dummy = Dummy()
         index.index_doc(1, dummy)
@@ -123,7 +125,7 @@ class PathIndexTests(unittest.TestCase):
 
     def test_index_doc_string_discrim_tuple_value(self):
         index = self._makeOne(discriminator='abc')
-        class Dummy:
+        class Dummy(object):
             abc = ('', 'a', 'b', 'c')
         dummy = Dummy()
         index.index_doc(1, dummy)
@@ -135,7 +137,7 @@ class PathIndexTests(unittest.TestCase):
 
     def test_index_doc_string_discrim_list_value(self):
         index = self._makeOne(discriminator='abc')
-        class Dummy:
+        class Dummy(object):
             abc = ['', 'a', 'b', 'c']
         dummy = Dummy()
         index.index_doc(1, dummy)
@@ -147,7 +149,7 @@ class PathIndexTests(unittest.TestCase):
 
     def test_index_doc_missing_value_unindexes(self):
         index = self._makeOne(discriminator='abc')
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.abc = '/a/b/c'
@@ -162,7 +164,7 @@ class PathIndexTests(unittest.TestCase):
     def test_index_doc_persistent_value_raises(self):
         from persistent import Persistent
         index = self._makeOne(discriminator='abc')
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.abc = Persistent()
@@ -171,7 +173,7 @@ class PathIndexTests(unittest.TestCase):
     def test_unindex_doc(self):
         index = self._makeOne(VALUES)
 
-        for doc_id in VALUES.keys():
+        for doc_id in list(VALUES.keys()):
             index.unindex_doc(doc_id)
 
         self.assertEqual(index.numObjects(), 0)
@@ -197,28 +199,28 @@ class PathIndexTests(unittest.TestCase):
 
     def test_searches_against_root_plain_string(self):
         index = self._makeOne(VALUES)
-        expected = range(1,19)
+        expected = list(range(1,19))
 
         results = list(index.apply('/').keys())
         self.assertEqual(results, expected)
 
     def test_searches_against_root_tuple(self):
         index = self._makeOne(VALUES)
-        expected = range(1,19)
+        expected = list(range(1,19))
 
         results = list(index.apply(('',)).keys())
         self.assertEqual(results, expected)
 
     def test_searches_against_root_list(self):
         index = self._makeOne(VALUES)
-        expected = range(1,19)
+        expected = list(range(1,19))
 
         results = list(index.apply(['']).keys())
         self.assertEqual(results, expected)
 
     def test_searches_against_root_wo_level(self):
         index = self._makeOne(VALUES)
-        expected = range(1,19)
+        expected = list(range(1,19))
 
         results = list(index.apply({'query': '/'}).keys())
         self.assertEqual(results, expected)
@@ -227,7 +229,7 @@ class PathIndexTests(unittest.TestCase):
         index = self._makeOne(VALUES)
         comp = "/"
         level = 0
-        expected = range(1,19)
+        expected = list(range(1,19))
 
         results = list(index.apply({'query': '/', 'level': 0}).keys())
         self.assertEqual(results, expected)
@@ -489,14 +491,14 @@ class PathIndexTests(unittest.TestCase):
 
     def test_applyEq(self):
         index = self._makeOne(VALUES)
-        expected = range(1,19)
+        expected = list(range(1,19))
 
         results = list(index.applyEq('/').keys())
         self.assertEqual(results, expected)
 
     def test_applyNotEq(self):
         index = self._makeOne(VALUES)
-        expected = range(1,10)
+        expected = list(range(1,10))
 
         results = list(index.applyNotEq('/bb').keys())
         self.assertEqual(results, expected)
@@ -549,7 +551,7 @@ class FakeTreeSet(set):
         self.add(thing)
 
 
-class Dummy:
+class Dummy(object):
 
     def __init__( self, path):
         self.path = path

--- a/repoze/catalog/indexes/tests/test_path2.py
+++ b/repoze/catalog/indexes/tests/test_path2.py
@@ -1,3 +1,5 @@
+from builtins import range
+from builtins import object
 import unittest
 
 _marker = object()
@@ -17,7 +19,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
             attr_discriminator = _attr_discriminator
         index = self._getTargetClass()(discriminator,
                                        attr_discriminator=attr_discriminator)
-        for doc_id, path in values.items():
+        for doc_id, path in list(values.items()):
             index.index_doc(doc_id, path)
         return index
 
@@ -78,13 +80,13 @@ class CatalogPathIndex2Tests(unittest.TestCase):
 
     def test_index_object_bad_path(self):
         index = self._makeOne()
-        class Dummy:
+        class Dummy(object):
             path = ()
         self.assertRaises(ValueError, index.index_doc, 1, Dummy())
 
     def test_index_object_simple(self):
         index = self._makeOne()
-        class Dummy:
+        class Dummy(object):
             path = '/abc'
         index.index_doc(1, Dummy())
         self.assertEqual(index.path_to_docid[('', 'abc')], 1)
@@ -94,7 +96,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         def _discriminator(obj, default):
             return '/abc'
         index = self._makeOne(discriminator=_discriminator)
-        class Dummy:
+        class Dummy(object):
             path = '/foo'
         index.index_doc(1, Dummy())
         self.assertEqual(index.path_to_docid[('', 'abc')], 1)
@@ -102,7 +104,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
 
     def test_index_object_missing_value_unindexes(self):
         index = self._makeOne()
-        class Dummy:
+        class Dummy(object):
             pass
         dummy = Dummy()
         dummy.path = '/abc'
@@ -118,7 +120,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
 
     def test_unindex_doc(self):
         index = self._makeOne(VALUES)
-        docids = VALUES.keys()
+        docids = list(VALUES.keys())
 
         for doc_id in docids:
             index.unindex_doc(doc_id)
@@ -161,12 +163,12 @@ class CatalogPathIndex2Tests(unittest.TestCase):
     def test_search_root_nodepth(self):
         index = self._makeOne(VALUES)
         result = index.search('/')
-        self.assertEqual(sorted(result), range(1, 21))
+        self.assertEqual(sorted(result), list(range(1, 21)))
 
     def test_search_root_nodepth_include_path(self):
         index = self._makeOne(VALUES)
         result = index.search('/', include_path=True)
-        self.assertEqual(sorted(result), range(0, 21))
+        self.assertEqual(sorted(result), list(range(0, 21)))
 
     def test_search_root_depth_0(self):
         index = self._makeOne(VALUES)
@@ -201,12 +203,12 @@ class CatalogPathIndex2Tests(unittest.TestCase):
     def test_search_root_depth_3(self):
         index = self._makeOne(VALUES)
         result = index.search('/', depth=3)
-        self.assertEqual(sorted(result), range(1, 21))
+        self.assertEqual(sorted(result), list(range(1, 21)))
 
     def test_search_root_depth_3_include_path(self):
         index = self._makeOne(VALUES)
         result = index.search('/', depth=3, include_path=True)
-        self.assertEqual(sorted(result), range(0, 21))
+        self.assertEqual(sorted(result), list(range(0, 21)))
 
     def test_search_aa_nodepth(self):
         index = self._makeOne(VALUES)
@@ -414,7 +416,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         attr_keys = sorted(index.docid_to_attr.keys())
         self.assertEqual(attr_keys, [0, 2, 8, 12])
 
-        docids = VALUES.keys()
+        docids = list(VALUES.keys())
 
         for doc_id in docids:
             index.unindex_doc(doc_id)
@@ -444,7 +446,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         index = self._makeOne(VALUES, attr_discriminator='attr')
         attr_checker = DummyAttrChecker()
         result = index.search('/', attr_checker=attr_checker)
-        self.assertEqual(sorted(result), range(1, 21))
+        self.assertEqual(sorted(result), list(range(1, 21)))
         results = sorted(attr_checker.results)
         self.assertEqual(len(results), 4)
         attrs, theset = results[3]
@@ -464,7 +466,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         index = self._makeOne(VALUES, attr_discriminator='attr')
         attr_checker = DummyAttrChecker()
         result = index.search('/', include_path=True, attr_checker=attr_checker)
-        self.assertEqual(sorted(result), range(0, 21))
+        self.assertEqual(sorted(result), list(range(0, 21)))
         results = sorted(attr_checker.results)
         self.assertEqual(len(results), 4)
         attrs, theset = results[3]
@@ -566,7 +568,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         index = self._makeOne(VALUES, attr_discriminator='attr')
         attr_checker = DummyAttrChecker()
         result = index.search('/', depth=3, attr_checker=attr_checker)
-        self.assertEqual(sorted(result), range(1, 21))
+        self.assertEqual(sorted(result), list(range(1, 21)))
         results = sorted(attr_checker.results)
         self.assertEqual(len(results), 4)
         attrs, theset = results[3]
@@ -587,7 +589,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         attr_checker = DummyAttrChecker()
         result = index.search('/', depth=3, include_path=True,
                               attr_checker=attr_checker)
-        self.assertEqual(sorted(result), range(0, 21))
+        self.assertEqual(sorted(result), list(range(0, 21)))
         results = sorted(attr_checker.results)
         self.assertEqual(len(results), 4)
         attrs, theset = results[3]
@@ -834,7 +836,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         index = self._makeOne(VALUES2, attr_discriminator='attr')
         attr_checker = DummyAttrChecker()
         result = index.search('/', attr_checker=attr_checker)
-        self.assertEqual(sorted(result), range(1, 6))
+        self.assertEqual(sorted(result), list(range(1, 6)))
         results = sorted(attr_checker.results)
         self.assertEqual(len(results), 6)
         attrs, theset = results[1]
@@ -860,7 +862,7 @@ class CatalogPathIndex2Tests(unittest.TestCase):
         index = self._makeOne(VALUES2, attr_discriminator='attr')
         attr_checker = DummyAttrChecker()
         result = index.search('/', include_path=True, attr_checker=attr_checker)
-        self.assertEqual(sorted(result), range(0, 6))
+        self.assertEqual(sorted(result), list(range(0, 6)))
         results = sorted(attr_checker.results)
         self.assertEqual(len(results), 6)
         attrs, theset = results[1]
@@ -955,7 +957,7 @@ class DummyAttrChecker(object):
         self.results = results
         return BTrees.family32.IF.multiunion([x[1] for x in results])
 
-class Dummy:
+class Dummy(object):
 
     def __init__( self, path, attr=None):
         self.path = path

--- a/repoze/catalog/indexes/tests/test_text.py
+++ b/repoze/catalog/indexes/tests/test_text.py
@@ -1,3 +1,6 @@
+from __future__ import division
+from past.builtins import basestring
+from past.utils import old_div
 import unittest
 
 _marker = object()
@@ -52,7 +55,7 @@ class TestCatalogTextIndex(unittest.TestCase):
     def test_reindex_doc_doesnt_unindex(self):
         index = self._makeOne()
         index.index_doc(5, 'now is the time')
-        index.unindex_doc = lambda *args, **kw: 1/0
+        index.unindex_doc = lambda *args, **kw: old_div(1,0)
         index.reindex_doc(5, 'now is the time')
 
     def test_sort_no_results(self):

--- a/repoze/catalog/indexes/text.py
+++ b/repoze/catalog/indexes/text.py
@@ -1,5 +1,5 @@
 from past.builtins import basestring
-from zope.interface import implements
+from zope.interface import implementer
 
 from zope.index.interfaces import IIndexSort
 from zope.index.text import TextIndex
@@ -7,6 +7,8 @@ from zope.index.text import TextIndex
 from repoze.catalog.interfaces import ICatalogIndex
 from repoze.catalog.indexes.common import CatalogIndex
 
+
+@implementer(ICatalogIndex, IIndexSort)
 class CatalogTextIndex(CatalogIndex, TextIndex):
     """ Full-text index.
 
@@ -20,8 +22,6 @@ class CatalogTextIndex(CatalogIndex, TextIndex):
 
     - NotEq
     """
-
-    implements(ICatalogIndex, IIndexSort)
 
     def __init__(self, discriminator, lexicon=None, index=None):
         if not callable(discriminator):

--- a/repoze/catalog/indexes/text.py
+++ b/repoze/catalog/indexes/text.py
@@ -1,3 +1,4 @@
+from past.builtins import basestring
 from zope.interface import implements
 
 from zope.index.interfaces import IIndexSort
@@ -37,7 +38,7 @@ class CatalogTextIndex(CatalogIndex, TextIndex):
         return self.index_doc(docid, object)
 
     def _indexed(self):
-        return self.index._docwords.keys()
+        return list(self.index._docwords.keys())
 
     def sort(self, result, reverse=False, limit=None, sort_type=None):
         """Sort by text relevance.
@@ -60,7 +61,7 @@ class CatalogTextIndex(CatalogIndex, TextIndex):
                 "result does not contain weights. To produce a weighted "
                 "result, include a text search in the query.")
 
-        items = [(weight, docid) for (docid, weight) in result.items()]
+        items = [(weight, docid) for (docid, weight) in list(result.items())]
         # when reverse is false, output largest weight first.
         # when reverse is true, output smallest weight first.
         items.sort(reverse=not reverse)

--- a/repoze/catalog/migration.py
+++ b/repoze/catalog/migration.py
@@ -22,17 +22,17 @@ IF = BTrees.family32.IF
 
 
 def migrate_to_0_8_0_from_document_map(catalog, document_map):
-    migrate_to_0_8_0_from_docids(catalog, document_map.docid_to_address.keys())
+    migrate_to_0_8_0_from_docids(catalog, list(document_map.docid_to_address.keys()))
 
 
 def migrate_to_0_8_0(catalog):
     docids = IF.multiunion([IF.Set(index._indexed()) for index
-                            in catalog.values() if hasattr(index, '_indexed')])
+                            in list(catalog.values()) if hasattr(index, '_indexed')])
     migrate_to_0_8_0_from_docids(catalog, docids)
 
 
 def migrate_to_0_8_0_from_docids(catalog, docids):
-    for index in catalog.values():
+    for index in list(catalog.values()):
         migrate = getattr(index, '_migrate_to_0_8_0', None)
         if migrate is not None:
             migrate(docids)

--- a/repoze/catalog/query.py
+++ b/repoze/catalog/query.py
@@ -807,6 +807,12 @@ class _AstParser(object):
         operator, query = children
         return operator(query)
 
+    def process_USub(self, node, children):
+        # Under python3, in an expresion like "a > -1", "-1" is parsed by the
+        # ast module as UnaryOp(USub, Num), instead of simply Num. Making our
+        # parser return this lambda makes the parsing work as expected
+        return lambda x: 0 - x
+
     def process_Compare(self, node, children):
         # Python allows arbitrary chaining of comparisons, ie:
         #   x == y == z != abc

--- a/repoze/catalog/query.py
+++ b/repoze/catalog/query.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import BTrees
 import sys
 
@@ -36,7 +37,7 @@ class Query(object):
         return ()
 
     def print_tree(self, out=sys.stdout, level=0):
-        print >> out, '  ' * level + str(self)
+        print('  ' * level + str(self), file=out)
         for child in self.iter_children():
             child.print_tree(out, level + 1)
 
@@ -934,7 +935,7 @@ def _print_ast(expr):  # pragma NO COVERAGE
     tree = ast.parse(expr)
 
     def visit(node, level):
-        print '  ' * level + str(node)
+        print('  ' * level + str(node))
         for child in ast.iter_child_nodes(node):
             visit(child, level + 1)
     visit(tree, 0)

--- a/repoze/catalog/query.py
+++ b/repoze/catalog/query.py
@@ -1,4 +1,7 @@
 from __future__ import print_function
+from builtins import str
+from builtins import range
+from builtins import object
 import BTrees
 import sys
 
@@ -496,7 +499,7 @@ class Or(BoolOp):
                 query_lower.negate(), query_upper.negate())
             queries[i_upper] = None
 
-        for i in xrange(len(queries)):
+        for i in range(len(queries)):
             query = queries[i]
             if type(query) in (Lt, Le):
                 match = uppers.get(query.index_name)
@@ -514,7 +517,7 @@ class Or(BoolOp):
                 else:
                     uppers[query.index_name] = (i, query)
 
-        queries = filter(None, queries)
+        queries = [_f for _f in queries if _f]
         if len(queries) == 1:
             return queries[0]
 
@@ -559,7 +562,7 @@ class And(BoolOp):
             queries[i_lower] = InRange.fromGTLT(query_lower, query_upper)
             queries[i_upper] = None
 
-        for i in xrange(len(queries)):
+        for i in range(len(queries)):
             query = queries[i]
             if type(query) in (Gt, Ge):
                 match = uppers.get(query.index_name)
@@ -577,7 +580,7 @@ class And(BoolOp):
                 else:
                     uppers[query.index_name] = (i, query)
 
-        queries = filter(None, queries)
+        queries = [_f for _f in queries if _f]
         if len(queries) == 1:
             return queries[0]
 
@@ -743,7 +746,7 @@ class _AstParser(object):
 
     def process_List(self, node, children):
         l = list(children[:-1])
-        for i in xrange(len(l)):
+        for i in range(len(l)):
             if isinstance(l[i], ast.Name):
                 l[i] = self._value(l[i])
         return l

--- a/repoze/catalog/tests/test_catalog.py
+++ b/repoze/catalog/tests/test_catalog.py
@@ -1,3 +1,4 @@
+from builtins import object
 import unittest
 
 _marker = object()
@@ -243,7 +244,7 @@ class TestCatalog(unittest.TestCase):
             3:Content('field3', ['keyword3', 'same'], 'text three',
                       '/path1/path2/path3'),
             }
-        for num, doc in map.items():
+        for num, doc in list(map.items()):
             catalog.index_doc(num, doc)
         num, result = catalog.search(field=('field1', 'field1'), **extra)
         self.assertEqual(num, 1)
@@ -376,11 +377,11 @@ class TestResultSetSize(unittest.TestCase):
         self.assertEqual(unpickled.total, 2)
         self.assertEqual(repr(unpickled), 'ResultSetSize(1, 2)')
 
-class DummyConnection:
+class DummyConnection(object):
     def close(self):
         self.closed = True
 
-class DummyTransaction:
+class DummyTransaction(object):
     def commit(self):
         self.committed = True
 

--- a/repoze/catalog/tests/test_catalog.py
+++ b/repoze/catalog/tests/test_catalog.py
@@ -386,10 +386,11 @@ class DummyTransaction(object):
         self.committed = True
 
 from repoze.catalog.catalog import ICatalogIndex
-from zope.interface import implements
+from zope.interface import implementer
 
+
+@implementer(ICatalogIndex)
 class DummyIndex(object):
-    implements(ICatalogIndex)
 
     value = None
     docid = None

--- a/repoze/catalog/tests/test_functional.py
+++ b/repoze/catalog/tests/test_functional.py
@@ -1,3 +1,4 @@
+from builtins import object
 import unittest
 from repoze.catalog import query as q
 

--- a/repoze/catalog/tests/test_migration.py
+++ b/repoze/catalog/tests/test_migration.py
@@ -1,3 +1,4 @@
+from builtins import object
 import unittest
 
 

--- a/repoze/catalog/tests/test_query.py
+++ b/repoze/catalog/tests/test_query.py
@@ -1,3 +1,7 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 import unittest
 from repoze.catalog.query import ast_support
 
@@ -59,7 +63,7 @@ class TestQuery(unittest.TestCase):
             def iter_children(self):
                 return self.children
 
-        from StringIO import StringIO
+        from io import StringIO
         a = Derived('A')
         b = Derived('B')
         c = Derived('C')

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@
 #
 ##############################################################################
 
-__version__ = '0.8.3'
+__version__ = '0.8.4'
 
 import os
 
@@ -27,6 +27,7 @@ except IOError:
 
 INSTALL_REQUIRES = [
     'setuptools',
+    'future',
     'zope.component',
     'ZODB3',
     'zope.index >= 3.5.0',
@@ -40,13 +41,15 @@ setup(name='repoze.catalog',
       description='Searching and indexing based on zope.index',
       long_description=README + '\n\n' +  CHANGES,
       classifiers=[
-        "Intended Audience :: Developers",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
+          "Intended Audience :: Developers",
+          "Programming Language :: Python",
+          "Programming Language :: Python :: 2",
+          "Programming Language :: Python :: 2.6",
+          "Programming Language :: Python :: 2.7",
+          "Programming Language :: Python :: 3",
+          "Programming Language :: Python :: 3.6",
+          "Programming Language :: Python :: Implementation :: CPython",
+          "Topic :: Internet :: WWW/HTTP :: Indexing/Search",
         ],
       keywords='indexing catalog search',
       author="Agendaless Consulting",


### PR DESCRIPTION
This pull requests contains the minimum changes to make it work with python 3. I've tried it in a python 3.6.1 env running part of that big code base I'm working on, so far it has worked fine (as good as it was running in a 2.7.13 env).

It uses the future package to keep backwards compatibility with python2.

On a next step I guess it would be nice to:

- take a look at how tests are written, as they are some cases where deprecated things like failUnless is used, but for now tests are passing.

- run pyflakes/pep8 and fix some of the errors/warnings reported there.

I can go on with that, but I'd like to get some feedback on this one first (thanks!)